### PR TITLE
Fix type in Str

### DIFF
--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -7,7 +7,7 @@ abstract class Str
     /**
      * Make the order reference using the given ID.
      *
-     * @param  int  $id
+     * @param  string  $id
      * @return string
      */
     public static function refFromId($id)


### PR DESCRIPTION
```php
	public function get_order_number() {
		return (string) apply_filters( 'woocommerce_order_number', $this->get_id(), $this );
	}
```