### PR TITLE
Skip items from the summary when item's price is 0

### DIFF
--- a/src/Payloads/PaymentPayload.php
+++ b/src/Payloads/PaymentPayload.php
@@ -117,7 +117,6 @@ abstract class PaymentPayload
                     $item instanceof WC_Order_Item_Fee ? [static::mapFeeItem($item)] : [static::mapLineItem($item)]
                 )
                 : $items;
-          };
         }, []), function ($item) {
             return isset($item['price']) && $item['price'] > 0;
         });

--- a/src/Payloads/PaymentPayload.php
+++ b/src/Payloads/PaymentPayload.php
@@ -111,10 +111,12 @@ abstract class PaymentPayload
     protected static function items(WC_Order $order)
     {
         return array_filter(array_reduce($order->get_items(['line_item', 'fee']), function ($items, $item) {
+          if($item->get_total() > 0) { /** if current item's price is not 0 */
             return array_merge(
                 $items,
                 $item instanceof WC_Order_Item_Fee ? [static::mapFeeItem($item)] : [static::mapLineItem($item)]
             );
+          };
         }, []), function ($item) {
             return isset($item['price']) && $item['price'] > 0;
         });

--- a/src/Payloads/PaymentPayload.php
+++ b/src/Payloads/PaymentPayload.php
@@ -111,11 +111,12 @@ abstract class PaymentPayload
     protected static function items(WC_Order $order)
     {
         return array_filter(array_reduce($order->get_items(['line_item', 'fee']), function ($items, $item) {
-          if($item->get_total() > 0) { /** if current item's price is not 0 */
-            return array_merge(
-                $items,
-                $item instanceof WC_Order_Item_Fee ? [static::mapFeeItem($item)] : [static::mapLineItem($item)]
-            );
+            return $item->get_total() > 0
+                ? array_merge(
+                    $items,
+                    $item instanceof WC_Order_Item_Fee ? [static::mapFeeItem($item)] : [static::mapLineItem($item)]
+                )
+                : $items;
           };
         }, []), function ($item) {
             return isset($item['price']) && $item['price'] > 0;


### PR DESCRIPTION
Ezzel az egy feltétel kiegészítéssel orvosolható, hogy az olyan rendelések esetén, ahol szerepel olyan termék, aminek 0 az ára, az bekavarjon a SimplePay rendszerébe, ami nem tudja lekezelni az olyan tömböt, amiben van nulla árú termék. Mert így a rendelt termékeket tartalmazó tömbe előállításakor, a SimplePay felé nem kerülnek továbbításra az árat amúgy sem befolyásoló tételek.

Ilyen eset előfordulhat például akkor ha egy bundle kezelő plugin a bundle nevét 0 árú termékként viszi fel a rendelésbe, vagy olyankor ha van valamilyen 0 árú ajádnék termék, aminek szintén kell szerepelnie a rendelésben.