### PR TITLE
Add filter to be able to customize the timeout

### DIFF
--- a/src/Payloads/PaymentPayload.php
+++ b/src/Payloads/PaymentPayload.php
@@ -172,7 +172,7 @@ abstract class PaymentPayload
      */
     public static function timeout(WC_Order $order): string
     {
-        $time = new DateTime('+30 minutes', wp_timezone());
+        $time = new DateTime(apply_filters('cone_simplepay_payment_timeout', '+30 minutes'), wp_timezone());
 
         return $time->format('c');
     }


### PR DESCRIPTION
The otp mobile IT team wants us to change this, but without a filter it's not doable

Usage

```php
add_filter('cone_simplepay_payment_timeout', fn () => '+90 minutes');
```