### PR TITLE
Paid order overwrite fix

### DIFF
--- a/src/Handlers/PaymentHandler.php
+++ b/src/Handlers/PaymentHandler.php
@@ -23,7 +23,8 @@ class PaymentHandler extends Handler
         $this->order->set_transaction_id($payload['t']);
 
         if ($payload['e'] === 'SUCCESS') {
-            $this->order->set_status('pending');
+			if (!$this->order->is_paid())
+            	$this->order->set_status('pending');
 
             if (PaymentPayload::shouldBeTwoStep($this->order)) {
                 $this->handleTwoStepPayment();

--- a/src/Handlers/PaymentHandler.php
+++ b/src/Handlers/PaymentHandler.php
@@ -23,8 +23,9 @@ class PaymentHandler extends Handler
         $this->order->set_transaction_id($payload['t']);
 
         if ($payload['e'] === 'SUCCESS') {
-            if (!$this->order->is_paid())
-			    $this->order->set_status('pending');
+            if (! $this->order->is_paid()) {
+	        $this->order->set_status('pending');	    
+	    }
 
             if (PaymentPayload::shouldBeTwoStep($this->order)) {
                 $this->handleTwoStepPayment();

--- a/src/Handlers/PaymentHandler.php
+++ b/src/Handlers/PaymentHandler.php
@@ -23,8 +23,8 @@ class PaymentHandler extends Handler
         $this->order->set_transaction_id($payload['t']);
 
         if ($payload['e'] === 'SUCCESS') {
-			if (!$this->order->is_paid())
-            	$this->order->set_status('pending');
+            if (!$this->order->is_paid())
+			    $this->order->set_status('pending');
 
             if (PaymentPayload::shouldBeTwoStep($this->order)) {
                 $this->handleTwoStepPayment();


### PR DESCRIPTION
## Symptoms
In some cases IPN calls may be finished earlier then redirect. Mostly on mobile devices, when user authenticates transaction in banking app, but forgets to instantly switch back to payment tab. In this case IPN sets order status to 'completed', then user returns to thank you page, where PaymentHandler overwrites the 'completed' status back to 'pending'. After a while WC Cron function 'wc_cancel_unpaid_orders' will automatically set order status to 'cancelled'.

This causes various errors:
- wrong order status
- wrong order->is_completed() result
- wrong products stock

## Fix
Set status to pending only if it was not already set to success or pending by IPN in the background.

## Proof
![simplepay_error_proof](https://user-images.githubusercontent.com/25059990/194099753-21551128-acad-489c-b424-aa2b71e8a697.png)

## Attention
Not sure if statement after fixed part should also be placed in condition. Please review.