### PR TITLE
Checkout Block Compatibility

### DIFF
--- a/includes/checkout.js
+++ b/includes/checkout.js
@@ -1,0 +1,25 @@
+(function () {
+    const settings = window.wc.wcSettings.getSetting('simplepay-gateway_data', {});
+    const label = window.wp.htmlEntities.decodeEntities(settings.title) || 'SimplePay';
+    const Content = () => {
+        return window.wp.htmlEntities.decodeEntities(settings.description || '');
+    };
+    const SimplePayCheckout = {
+        name: 'simplepay-gateway',
+        label: React.createElement('img', {
+            src: `${settings.icon}`,
+            alt: window.wp.htmlEntities.decodeEntities(settings.title || 'SimplePay'),
+        }),
+        content: Object(window.wp.element.createElement)(Content, null),
+        edit: Object(window.wp.element.createElement)(Content, null),
+        canMakePayment: () => true,
+        // placeOrderButtonLabel: window.wp.i18n.__( 'Proceed to Barion', 'pay-via-barion-for-woocommerce' ),
+        ariaLabel: label,
+        supports: {
+            features: settings.supports,
+        },
+    };
+    window.wc.wcBlocksRegistry.registerPaymentMethod(SimplePayCheckout);
+    console.log(SimplePayCheckout);
+    console.log(settings);
+})();

--- a/includes/checkout.js
+++ b/includes/checkout.js
@@ -13,7 +13,6 @@
         content: Object(window.wp.element.createElement)(Content, null),
         edit: Object(window.wp.element.createElement)(Content, null),
         canMakePayment: () => true,
-        // placeOrderButtonLabel: window.wp.i18n.__( 'Proceed to Barion', 'pay-via-barion-for-woocommerce' ),
         ariaLabel: label,
         supports: {
             features: settings.supports,

--- a/includes/checkout.js
+++ b/includes/checkout.js
@@ -19,6 +19,4 @@
         },
     };
     window.wc.wcBlocksRegistry.registerPaymentMethod(SimplePayCheckout);
-    console.log(SimplePayCheckout);
-    console.log(settings);
 })();

--- a/simplepay-gateway.php
+++ b/simplepay-gateway.php
@@ -24,10 +24,11 @@ require_once __DIR__.'/autoload.php';
 register_activation_hook(__FILE__, [Cone\SimplePay\Plugin::class, 'activate']);
 register_deactivation_hook(__FILE__, [Cone\SimplePay\Plugin::class, 'deactivate']);
 
-// Declare HPOS compatibility
+// Declare HPOS & Checkout Block compatibility
 add_action('before_woocommerce_init', function () {
     if (class_exists(Automattic\WooCommerce\Utilities\FeaturesUtil::class)) {
         Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('custom_order_tables', __FILE__, true);
+        Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('cart_checkout_blocks', __FILE__, true);
     }
 });
 

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -15,6 +15,8 @@ use Cone\SimplePay\Support\Str;
 use Exception;
 use WC_Order;
 use WC_Payment_Gateway;
+use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
+use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
 
 class Gateway extends WC_Payment_Gateway
 {
@@ -363,14 +365,13 @@ class Gateway extends WC_Payment_Gateway
      */
     public static function initBlock()
     {
-        if( ! class_exists( 'Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType' ) ) {
+        if( ! class_exists( AbstractPaymentMethodType::class ) ) {
             return;
         }
 
-        require_once 'GatewayBlock.php';
         add_action(
             'woocommerce_blocks_payment_method_type_registration',
-            function (\Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry $payment_method_registry) {
+            function (PaymentMethodRegistry $payment_method_registry) {
                 $payment_method_registry->register( new GatewayBlock );
         } );
     }

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -119,7 +119,7 @@ class Gateway extends WC_Payment_Gateway
         $this->method_description = __('OTP SimplePay Payment Gateway', 'cone-simplepay');
 
         if (isset($this->show_icon) && $this->show_icon === 'yes') {
-            $this->icon = apply_filters('cone_simplepay_icon', plugin_dir_url(__DIR__).'/images/icon.png');
+            $this->icon = apply_filters('cone_simplepay_icon', plugin_dir_url(__DIR__).'images/icon.png');
         }
     }
 
@@ -357,6 +357,25 @@ class Gateway extends WC_Payment_Gateway
     }
 
     /**
+     * Init checkout block compatibility.
+     *
+     * @return void
+     */
+    public static function initBlock()
+    {
+        if( ! class_exists( 'Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType' ) ) {
+            return;
+        }
+
+        require_once 'GatewayBlock.php';
+        add_action(
+            'woocommerce_blocks_payment_method_type_registration',
+            function (\Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry $payment_method_registry) {
+                $payment_method_registry->register( new GatewayBlock );
+        } );
+    }
+
+    /**
      * Register the hooks.
      *
      * @return void
@@ -370,5 +389,6 @@ class Gateway extends WC_Payment_Gateway
         add_action("woocommerce_api_wc_gateway_{$this->id}", [$this, 'handleNotification']);
         add_action('woocommerce_order_details_after_order_table_items', [$this, 'extnendOrderTable']);
         add_action("woocommerce_update_options_payment_gateways_{$this->id}", [$this, 'process_admin_options']);
+        add_action('woocommerce_blocks_loaded', [$this, 'initBlock']);
     }
 }

--- a/src/GatewayBlock.php
+++ b/src/GatewayBlock.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Cone\SimplePay;
+use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
+
+final class GatewayBlock extends AbstractPaymentMethodType {
+	private $gateway;
+	protected $name = 'simplepay-gateway';
+
+	public function initialize() {
+		$this->settings = get_option( 'woocommerce_simplepay-gateway_settings', [] );
+		$this->gateway = new Gateway();
+	}
+
+	public function is_active() {
+		return $this->get_setting( 'enabled' ) === 'yes';
+	}
+
+	public function get_payment_method_script_handles() {
+		wp_register_script(
+			'simplepay-gateway-blocks-integration',
+			plugin_dir_url(__DIR__). '/includes/checkout.js',
+			[
+				'wc-blocks-registry',
+				'wc-settings',
+				'wp-element',
+				'wp-html-entities',
+				'wp-i18n',
+			],
+			null,
+			true
+		);
+		if( function_exists( 'wp_set_script_translations' ) ) {
+			wp_set_script_translations( 'simplepay-gateway-blocks-integration');
+		}
+
+		return [ 'simplepay-gateway-blocks-integration' ];
+	}
+
+	public function get_payment_method_data() {
+		return [
+			'title' => $this->gateway->title,
+			'description' => $this->gateway->description,
+            'icon' => $this->gateway->icon
+		];
+	}
+
+}

--- a/src/GatewayBlock.php
+++ b/src/GatewayBlock.php
@@ -41,7 +41,7 @@ final class GatewayBlock extends AbstractPaymentMethodType {
 		return [
 			'title' => $this->gateway->title,
 			'description' => $this->gateway->description,
-            'icon' => $this->gateway->icon
+			'icon' => $this->gateway->icon
 		];
 	}
 

--- a/src/GatewayBlock.php
+++ b/src/GatewayBlock.php
@@ -19,7 +19,7 @@ final class GatewayBlock extends AbstractPaymentMethodType {
 	public function get_payment_method_script_handles() {
 		wp_register_script(
 			'simplepay-gateway-blocks-integration',
-			plugin_dir_url(__DIR__). '/includes/checkout.js',
+			plugin_dir_url(__DIR__). 'includes/checkout.js',
 			[
 				'wc-blocks-registry',
 				'wc-settings',


### PR DESCRIPTION
Woo 8.3-tól új telepítéseknél az új Checkout Block az alapértelmezett pénztár oldal, ahol a fizetési módot kicsit máshogy kell betölteni. Sandbox fiókkal teszteltem. A logó elég pici, mert rajta van az otp... felirat is. Nem tudom, hogy szabad e anélkül használni, úgy jobban nézne ki. 

<img width="762" alt="image" src="https://github.com/conedevelopment/simplepay-gateway/assets/43415/18abc27f-6ae0-410c-b41e-7d2b807a5995">
